### PR TITLE
Code to delete the test application after paramedic run.

### DIFF
--- a/lib/ParamedicConfig.js
+++ b/lib/ParamedicConfig.js
@@ -21,7 +21,8 @@ ParamedicConfig.parseFromArguments = function (argv) {
         "startPort": argv.startport || argv.port,
         "endPort":   argv.endport || argv.port,
         "externalServerUrl": argv.externalServerUrl,
-        "reportSavePath":  !!argv.reportSavePath? argv.reportSavePath: undefined
+        "reportSavePath":  !!argv.reportSavePath? argv.reportSavePath: undefined,
+        "cleanUpAfterRun": !!argv.cleanUpAfterRun? true: false
     });
 };
 
@@ -36,6 +37,10 @@ ParamedicConfig.prototype.useTunnel = function () {
 
 ParamedicConfig.prototype.getReportSavePath = function () {
     return this._config.reportSavePath;
+};
+
+ParamedicConfig.prototype.shouldCleanUpAfterRun = function () {
+    return this._config.cleanUpAfterRun;
 };
 
 ParamedicConfig.prototype.getTargets = function () {

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -15,6 +15,10 @@ var exec = require('./utils').exec,
 var Q = require('q');
 var logger = require('./logger').get();
 
+var TESTS_PASS = 0;
+var TESTS_FAILURE = 1;
+var NONTESTS_FAILURE = 2;
+
 function ParamedicRunner(config, _callback) {
     this.tunneledUrl = "";
     this.tempFolder = null;
@@ -106,14 +110,21 @@ ParamedicRunner.prototype = {
         }).then(function(res) {
             if (self.testsPassed) {
                 logger.info("All tests have been passed.");
-                process.exit(0);
+                return TESTS_PASS;
             } else {
                 logger.error("There are tests failures.");
-                process.exit(1);
+                return TESTS_FAILURE;
             }
         }, function(err) {
             logger.error("Failed: " + err);
-            process.exit(2);
+            return NONTESTS_FAILURE;
+        }).then(function(exitCode){
+            if(self.config.shouldCleanUpAfterRun()) {
+                logger.info("cordova-paramedic: Deleting the application: " + self.tempFolder.name);
+                shell.popd();
+                shell.rm('-rf', self.tempFolder.name);
+            }
+            process.exit(exitCode);
         });
     },
     createTempProject: function() {
@@ -121,7 +132,7 @@ ParamedicRunner.prototype = {
         tmp.setGracefulCleanup();
         logger.info("cordova-paramedic: creating temp project at " + this.tempFolder.name);
         exec('cordova create ' + this.tempFolder.name);
-        shell.cd(this.tempFolder.name);
+        shell.pushd(this.tempFolder.name);
     },
     installPlugins: function() {
         logger.info("cordova-paramedic: installing plugins");

--- a/main.js
+++ b/main.js
@@ -23,7 +23,8 @@ var USAGE = "Error missing args. \n" +
     "--browserify : (optional) plugins are browserified into cordova.js \n" +
     "--verbose : (optional) verbose mode. Display more information output\n" +
     "--useTunnel : use tunneling instead of local address. default is false\n" +
-    "--savePath: (optional) path to save Junit results file."
+    "--reportSavePath: (optional) path to save Junit results file\n" +
+    "--cleanUpAfterRun: (optional) cleans up the application after the run."
 
 var argv = parseArgs(process.argv.slice(2));
 var pathToParamedicConfig = argv.config && path.resolve(argv.config);


### PR DESCRIPTION
**Requirements**
Per the design of cordova-paramedic, a new test application is created (in tmp folder) for every run. With enough runs (especially in CI) this would take a lot of space. We must enable the system to delete the application based on a flag. 

**Design**
1. Introduced new flag "cleanUpAfterRun"
2. Based on the new flag, the test application folder will be deleted recursively (before exiting)
3. Added the new flag details to the help text.

@dblotsky @riknoll @sgrebnov Can you please review and merge this PR?
